### PR TITLE
Binary content update:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
-FROM ubuntu:xenial
+FROM ubuntu:18.04
 RUN apt-get update -qq && apt-get upgrade -y
 
-RUN apt-get install -y curl unzip build-essential openjdk-8-jdk-headless gradle
+RUN apt-get install -y curl unzip build-essential openjdk-8-jdk-headless wget
+RUN wget https://services.gradle.org/distributions/gradle-5.1.1-bin.zip -P /tmp && unzip -d /opt/gradle /tmp/gradle-*.zip && mv /opt/gradle/gradle-*/* /opt/gradle/
+RUN export PATH=$PATH:/opt/gradle/bin
 
 ADD ./build.gradle /app/build.gradle
-RUN cd /app && gradle build -x :bootRepackage -x test --continue
+RUN export PATH=$PATH:/opt/gradle/bin && cd /app && gradle build -x test --continue
 
 ADD . /app
 WORKDIR /app
-RUN make build
+RUN export PATH=$PATH:/opt/gradle/bin && make build
 
 FROM anapsix/alpine-java:8
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ group = 'com.oisp'
 
 buildscript {
     ext {
-        springBootVersion = '1.5.9.RELEASE'
+        springBootVersion = '2.1.2.RELEASE'
     }
     repositories {
         mavenLocal()
@@ -107,6 +107,7 @@ configurations {
     compile.exclude group: "org.mortbay.jetty"
     compile.exclude group: "tomcat"
     compile.exclude module: "slf4j-log4j12"
+    compile.exclude module: "org.apache.logging.log4j"
     compile.exclude group: "org.eclipse.jetty.websocket"
     compile.exclude group: "javax.servlet", module: "servlet-api"
     compile.exclude group: "ch.qos.logback"
@@ -114,13 +115,17 @@ configurations {
 
 
 dependencies {
-    compile("org.springframework.boot:spring-boot-starter-web") 
-    compile("org.springframework.boot:spring-boot-starter-jetty")
-    compile("org.springframework.boot:spring-boot-starter-log4j2")
+    compile("org.springframework.boot:spring-boot-starter-web:${springBootVersion}") {exclude group: "org.apache.logging.log4j"}
+    compile("org.springframework.boot:spring-boot-starter-jetty:${springBootVersion}")
+    compile("org.springframework.boot:spring-boot-starter-log4j2:${springBootVersion}")
+    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.9.8'
 // https://mvnrepository.com/artifact/io.opentracing.contrib/opentracing-spring-web-autoconfigure
     compile group: 'io.opentracing.contrib', name: 'opentracing-spring-web-autoconfigure', version: '0.3.2'
     compile group: 'io.jaegertracing', name: 'jaeger-core', version: '0.31.0'
     compile group: 'io.jaegertracing', name: 'jaeger-thrift', version: '0.31.0'
+    compile group: 'org.springframework.boot', name: 'spring-boot-autoconfigure', version: "${springBootVersion}"
+
+
 
 
 
@@ -161,7 +166,7 @@ dependencies {
     testCompile "org.powermock:powermock-api-mockito:1.6.2"
     testCompile "org.powermock:powermock-module-junit4:1.6.2"
     testCompile "org.powermock:powermock-module-testng:1.6.2"
-    testCompile "org.springframework:spring-test:4.1.6.RELEASE"
+    testCompile "org.springframework:spring-test:5.0.4.RELEASE"
     testCompile "org.hamcrest:hamcrest-all:1.3"
     testCompile "com.btmatthews.hamcrest:hamcrest-matchers:1.0.1"
 

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -66,7 +66,7 @@
 
         <module name="MethodLength"/>
         <module name="ParameterNumber">
-            <property name="max" value="8"/>
+            <property name="max" value="9"/>
         </module>
 
         <module name="EmptyForIteratorPad"/>

--- a/src/main/java/com/oisp/databackend/api/DataSubmissionService.java
+++ b/src/main/java/com/oisp/databackend/api/DataSubmissionService.java
@@ -30,6 +30,7 @@ import static org.springframework.web.context.WebApplicationContext.SCOPE_REQUES
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 @org.springframework.stereotype.Service
 @Scope(value = SCOPE_REQUEST, proxyMode = TARGET_CLASS)
 public class DataSubmissionService implements Service<DataSubmissionRequest, DataSubmissionResponse> {
@@ -56,10 +57,11 @@ public class DataSubmissionService implements Service<DataSubmissionRequest, Dat
 
     @Override
     public DataSubmissionResponse invoke() throws MissingDataSubmissionArgumentException {
-        logger.error("=============DataSubmissionResponse");
+        logger.debug("=============DataSubmissionResponse");
         if (request.getData() == null) {
             throw new MissingDataSubmissionArgumentException("Missing \"data\" field in request");
         }
+
         for (Observation o : request.getData()) {
             o.setAid(accountId);
             o.setSystemOn(this.request.getSystemOn());

--- a/src/main/java/com/oisp/databackend/api/FirstLastTimestampService.java
+++ b/src/main/java/com/oisp/databackend/api/FirstLastTimestampService.java
@@ -78,7 +78,7 @@ public class FirstLastTimestampService implements Service<FirstLastTimestampRequ
     }
 
     private Observation[] getTopObservation(String component, boolean first) {
-        return hbase.scan(accountId, component,
+        return hbase.scan(accountId, component, "ByteArray", //ByteArray is used to avoid interpretation of value since only the timestamps are needed
                 0L,
                 Long.MAX_VALUE,
                 false,

--- a/src/main/java/com/oisp/databackend/api/helpers/Common.java
+++ b/src/main/java/com/oisp/databackend/api/helpers/Common.java
@@ -29,7 +29,7 @@ public final class Common {
     private Common() {
     }
 
-    public static void addObservationLocation(Observation observation, List<String> samples, int maxCoordinatesCount) {
+    public static void addObservationLocation(Observation observation, List<Object> samples, int maxCoordinatesCount) {
         if (observation.getLoc() == null) {
             logger.warn("Parsing GPS failed - no location info provided");
             return;

--- a/src/main/java/com/oisp/databackend/api/inquiry/DataRetriever.java
+++ b/src/main/java/com/oisp/databackend/api/inquiry/DataRetriever.java
@@ -20,6 +20,7 @@ import com.oisp.databackend.api.inquiry.advanced.filters.ObservationFilterSelect
 import com.oisp.databackend.datasources.DataDao;
 import com.oisp.databackend.datastructures.ComponentDataType;
 import com.oisp.databackend.datastructures.Observation;
+import com.oisp.databackend.exceptions.IllegalDataInquiryArgumentException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,13 +46,18 @@ public class DataRetriever {
         this.dataRetrieveParams = dataRetrieveParams;
     }
 
-    public void retrieveAndCount(ObservationFilterSelector filter) {
+    public void retrieveAndCount(ObservationFilterSelector filter) throws IllegalDataInquiryArgumentException {
         Map<String, Observation[]> componentObservations = new HashMap<>();
         Collection<String> components = dataRetrieveParams.getComponentsMetadata().keySet();
         rowCount = 0L;
         for (String component : components) {
+            if (dataRetrieveParams.getComponentsMetadata().get((String) component) == null
+                     || !dataRetrieveParams.getComponentsMetadata().get((String) component).isValidType()) {
+                throw new IllegalDataInquiryArgumentException("Invalid ComponentType.");
+            }
             Observation[] observations = hbase.scan(dataRetrieveParams.getAccountId(),
                     component,
+                    dataRetrieveParams.getComponentsMetadata().get((String) component).getDataType(),
                     dataRetrieveParams.getStartDate(),
                     dataRetrieveParams.getEndDate(),
                     dataRetrieveParams.isQueryMeasureLocation(),

--- a/src/main/java/com/oisp/databackend/api/inquiry/samples/SampleAggregationDataRetriever.java
+++ b/src/main/java/com/oisp/databackend/api/inquiry/samples/SampleAggregationDataRetriever.java
@@ -40,11 +40,11 @@ public class SampleAggregationDataRetriever implements SampleDataRetriever {
     }
 
     @Override
-    public List<List<String>> get(Observation[] observations, Long first, Long last) {
+    public List<List<Object>> get(Observation[] observations, Long first, Long last) {
         //group by getTimestamp bucket and count averages in each bucket.
         //Stream based solution could be easier to parallelize (and read).
 
-        List<List<String>> sampleObservationList = new ArrayList<>();
+        List<List<Object>> sampleObservationList = new ArrayList<>();
         if (observations.length == 0) {
             return sampleObservationList;
         }
@@ -74,11 +74,11 @@ public class SampleAggregationDataRetriever implements SampleDataRetriever {
         return sampleObservationList;
     }
 
-    private void createSample(double sumValue, long sumTime, long count, List<List<String>> sampleObservationList) {
+    private void createSample(double sumValue, long sumTime, long count, List<List<Object>> sampleObservationList) {
         double avgValue = sumValue / count;
         long avgTime = sumTime / count;
         logger.debug("Avgs for bucket for component are: getValue={} time={} count={}", avgValue, avgTime, count);
-        List<String> samples = new ArrayList<>();
+        List<Object> samples = new ArrayList<>();
         samples.add(String.valueOf(avgTime));
         samples.add(String.valueOf(avgValue));
         sampleObservationList.add(samples);

--- a/src/main/java/com/oisp/databackend/api/inquiry/samples/SampleDataRetriever.java
+++ b/src/main/java/com/oisp/databackend/api/inquiry/samples/SampleDataRetriever.java
@@ -22,5 +22,5 @@ import java.util.List;
 
 public interface SampleDataRetriever {
 
-    List<List<String>> get(Observation[] observations, Long first, Long last);
+    List<List<Object>> get(Observation[] observations, Long first, Long last);
 }

--- a/src/main/java/com/oisp/databackend/api/inquiry/samples/SamplePlainDataRetriever.java
+++ b/src/main/java/com/oisp/databackend/api/inquiry/samples/SamplePlainDataRetriever.java
@@ -31,14 +31,18 @@ public class SamplePlainDataRetriever implements SampleDataRetriever {
     }
 
     @Override
-    public List<List<String>> get(Observation[] observations, Long first, Long last) {
-        List<List<String>> sampleObservationList = new ArrayList<>();
+    public List<List<Object>> get(Observation[] observations, Long first, Long last) {
+        List<List<Object>> sampleObservationList = new ArrayList<>();
         int maxCoordinatesCount = Common.getMaxCoordinatesCount(observations);
         for (Long i = first; i < last; i++) {
             Observation observation = observations[i.intValue()];
-            List<String> samples = new ArrayList<>();
-            samples.add(observation.getOn().toString());
-            samples.add(observation.getValue());
+            List<Object> samples = new ArrayList<>();
+            samples.add(observation.getOn());
+            if (observation.isBinary()) {
+                samples.add(observation.getbValue());
+            } else {
+                samples.add(observation.getValue());
+            }
             sampleObservationList.add(samples);
             Common.addObservationLocation(observation, samples, maxCoordinatesCount);
             addObservationAttributes(observation, samples);
@@ -47,7 +51,7 @@ public class SamplePlainDataRetriever implements SampleDataRetriever {
 
     }
 
-    private void addObservationAttributes(Observation observation, List<String> samples) {
+    private void addObservationAttributes(Observation observation, List<Object> samples) {
         if (observationAttributes != null) {
             for (String attrName : observationAttributes) {
                 String attrValue = observation.getAttributes().get(attrName);

--- a/src/main/java/com/oisp/databackend/datasources/DataDao.java
+++ b/src/main/java/com/oisp/databackend/datasources/DataDao.java
@@ -19,16 +19,19 @@ package com.oisp.databackend.datasources;
 import com.oisp.databackend.datastructures.Observation;
 
 import java.io.IOException;
+import java.util.List;
 
 public interface DataDao {
 
 
     boolean put(Observation[] o);
 
-    Observation[] scan(String accountId, String componentId, long start, long stop, Boolean gps, String[] attributes);
+    Observation[] scan(String accountId, String componentId, String componentType, long start, long stop, Boolean gps, String[] attributes);
 
-    Observation[] scan(String accountId, String componentId, long start, long stop, Boolean gps, String[] attributes,
+    Observation[] scan(String accountId, String componentId, String componentType, long start, long stop, Boolean gps, String[] attributes,
                        boolean forward, int limit);
 
     String[] scanForAttributeNames(String accountId, String componentId, long start, long stop) throws IOException;
+
+    List<String> getSupportedDataTypes();
 }

--- a/src/main/java/com/oisp/databackend/datasources/DataDaoImpl.java
+++ b/src/main/java/com/oisp/databackend/datasources/DataDaoImpl.java
@@ -71,11 +71,12 @@ public class DataDaoImpl implements DataDao {
     }
 
     @Override
-    public Observation[] scan(String accountId, String componentId, long start, long stop, Boolean gps, String[] attributeList) {
+    public Observation[] scan(String accountId, String componentId, String componentType, long start, long stop, Boolean gps, String[] attributeList) {
         logger.debug("Scanning TSDB: acc: {} cid: {} start: {} stop: {} gps: {}", accountId, componentId, start, stop, gps);
         TsdbQuery tsdbQuery = new TsdbQuery()
                 .withAid(accountId)
                 .withCid(componentId)
+                .withComponentType(componentType)
                 .withLocationInfo(gps)
                 .withAttributes(attributeList)
                 .withStart(start)
@@ -84,13 +85,14 @@ public class DataDaoImpl implements DataDao {
     }
 
     @Override
-    public Observation[] scan(String accountId, String componentId, long start, long stop, Boolean gps,
+    public Observation[] scan(String accountId, String componentId, String componentType, long start, long stop, Boolean gps,
                               String[] attributeList, boolean forward, int limit) {
         logger.debug("Scanning TSDB: acc: {} cid: {} start: {} stop: {} gps: {} with limit: {}",
                 accountId, componentId, start, stop, gps, limit);
         TsdbQuery tsdbQuery = new TsdbQuery()
                 .withAid(accountId)
                 .withCid(componentId)
+                .withComponentType(componentType)
                 .withLocationInfo(gps)
                 .withAttributes(attributeList)
                 .withStart(start)
@@ -117,5 +119,10 @@ public class DataDaoImpl implements DataDao {
                         && !s.equals(DataFormatter.gpsValueToString(1))
                         && !s.equals(DataFormatter.gpsValueToString(2))).toArray(String[]::new);*/
         return attributesArray;
+    }
+
+    @Override
+    public List<String> getSupportedDataTypes() {
+        return tsdbAccess.getSupportedDataTypes();
     }
 }

--- a/src/main/java/com/oisp/databackend/datasources/tsdb/TsdbAccess.java
+++ b/src/main/java/com/oisp/databackend/datasources/tsdb/TsdbAccess.java
@@ -68,4 +68,9 @@ public interface TsdbAccess {
      * @throws IOException
      */
     String[] scanForAttributeNames(TsdbQuery tsdbQuery) throws IOException;
+
+    /**
+     * Get list of data types which are supported by tsdb backend
+     */
+    List<String> getSupportedDataTypes();
 }

--- a/src/main/java/com/oisp/databackend/datasources/tsdb/TsdbQuery.java
+++ b/src/main/java/com/oisp/databackend/datasources/tsdb/TsdbQuery.java
@@ -7,6 +7,7 @@ import java.util.List;
 public class TsdbQuery {
     private String aid;
     private String cid;
+    private String componentType;
     private List<String>  attributes;
     private boolean locationInfo;
     private long start;
@@ -15,6 +16,7 @@ public class TsdbQuery {
     public TsdbQuery(String aid, String cid, List<String> attributes, boolean locationInfo, long start, long stop) {
         this.aid = aid;
         this.cid = cid;
+        this.componentType = null;
         this.attributes = attributes;
         this.locationInfo = locationInfo;
         this.start = start;
@@ -23,6 +25,7 @@ public class TsdbQuery {
 
     public TsdbQuery() {
         this.locationInfo = false;
+        this.componentType = null;
         this.attributes = new ArrayList<>();
     }
 
@@ -33,6 +36,11 @@ public class TsdbQuery {
 
     public TsdbQuery withCid(String cid) {
         this.cid = cid;
+        return this;
+    }
+
+    public TsdbQuery withComponentType(String componentType) {
+        this.componentType = componentType;
         return this;
     }
 
@@ -112,5 +120,13 @@ public class TsdbQuery {
 
     public long getStop() {
         return stop;
+    }
+
+    public String getComponentType() {
+        return componentType;
+    }
+
+    public void setComponentType(String componentType) {
+        this.componentType = componentType;
     }
 }

--- a/src/main/java/com/oisp/databackend/datasources/tsdb/dummy/TsdbAccessDummy.java
+++ b/src/main/java/com/oisp/databackend/datasources/tsdb/dummy/TsdbAccessDummy.java
@@ -55,4 +55,9 @@ public class TsdbAccessDummy implements TsdbAccess {
         return new String[0];
     }
 
+    @Override
+    public List<String> getSupportedDataTypes() {
+        return Arrays.asList("Number", "String", "Boolean", "ByteArray");
+    }
+
 }

--- a/src/main/java/com/oisp/databackend/datasources/tsdb/opentsdb/TsdbAccessOpenTsdb.java
+++ b/src/main/java/com/oisp/databackend/datasources/tsdb/opentsdb/TsdbAccessOpenTsdb.java
@@ -112,4 +112,8 @@ public class TsdbAccessOpenTsdb implements TsdbAccess {
         return new String[]{"*"};
     }
 
+    @Override
+    public List<String> getSupportedDataTypes() {
+        return Arrays.asList("Number", "Boolean");
+    }
 }

--- a/src/main/java/com/oisp/databackend/datastructures/AdvancedComponent.java
+++ b/src/main/java/com/oisp/databackend/datastructures/AdvancedComponent.java
@@ -42,7 +42,7 @@ public class AdvancedComponent {
     private Double sum;
     private Double sumOfSquares;
     private List<String> samplesHeader;
-    private List<List<String>> samples;  // [<timestamp_2>,"<sample_2>",latitude,longitude,altitude],
+    private List<List<Object>> samples;  // [<timestamp_2>,"<sample_2>",latitude,longitude,altitude],
 
     public String toString() {
         return JsonWriter.objectToJson(this);
@@ -120,11 +120,11 @@ public class AdvancedComponent {
         this.samplesHeader = samplesHeader;
     }
 
-    public List<List<String>> getSamples() {
+    public List<List<Object>> getSamples() {
         return samples;
     }
 
-    public void setSamples(List<List<String>> samples) {
+    public void setSamples(List<List<Object>> samples) {
         this.samples = samples;
     }
 

--- a/src/main/java/com/oisp/databackend/datastructures/Component.java
+++ b/src/main/java/com/oisp/databackend/datastructures/Component.java
@@ -27,7 +27,7 @@ public class Component {
 
     private String componentId;
     private List<String> samplesHeader;   // ["Timestamp", "Value", "lat", "lon", "alt", "att1", "att2"]
-    private List<List<String>> samples;   // [<timestamp_2>,"<sample_2>",latitude,longitude,altitude],
+    private List<List<Object>> samples;   // [<timestamp_2>,"<sample_2>",latitude,longitude,altitude],
 
     public String getComponentId() {
         return componentId;
@@ -45,11 +45,11 @@ public class Component {
         this.samplesHeader = samplesHeader;
     }
 
-    public List<List<String>> getSamples() {
+    public List<List<Object>> getSamples() {
         return samples;
     }
 
-    public void setSamples(List<List<String>> samples) {
+    public void setSamples(List<List<Object>> samples) {
         this.samples = samples;
     }
 

--- a/src/main/java/com/oisp/databackend/datastructures/ComponentDataType.java
+++ b/src/main/java/com/oisp/databackend/datastructures/ComponentDataType.java
@@ -22,7 +22,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ComponentDataType {
 
-    public static final String NUMBER = "Number";
+    public static final String NUMBER    = "Number";
+    public static final String STRING    = "String";
+    public static final String BOOLEAN   = "Boolean";
+    public static final String BYTEARRAY = "ByteArray";
+
 
     private String componentId;
     private String componentType;
@@ -76,6 +80,24 @@ public class ComponentDataType {
 
     public boolean isNumericType() {
         return getDataType().equals(NUMBER);
+    }
+    public boolean isStringType() {
+        return getDataType().equals(STRING);
+    }
+    public boolean isBooleanType() {
+        return getDataType().equals(BOOLEAN);
+    }
+    public boolean isByteArrayType() {
+        return getDataType().equals(BYTEARRAY);
+    }
+    public boolean isBinaryType() {
+        return getDataType().equals(BYTEARRAY);
+    }
+    public boolean isValidType() {
+        return getDataType().equals(NUMBER)
+                || getDataType().equals(STRING)
+                || getDataType().equals(BOOLEAN)
+                || getDataType().equals(BYTEARRAY);
     }
 }
 

--- a/src/main/java/com/oisp/databackend/datastructures/Observation.java
+++ b/src/main/java/com/oisp/databackend/datastructures/Observation.java
@@ -35,6 +35,7 @@ public class Observation {
     private Long on;
     private Long systemOn;
     private String value;
+    private byte[] bValue;
     private List<Double> loc;
     private Map<String, String> attributes;
     private String dataType;
@@ -130,5 +131,17 @@ public class Observation {
 
     public void setSystemOn(Long systemOn) {
         this.systemOn = systemOn;
+    }
+
+    public byte[] getbValue() {
+        return bValue;
+    }
+
+    public void setbValue(byte[] bValue) {
+        this.bValue = bValue;
+    }
+
+    public boolean isBinary() {
+        return "ByteArray".equals(dataType);
     }
 }

--- a/src/main/java/com/oisp/databackend/handlers/MessageConverter.java
+++ b/src/main/java/com/oisp/databackend/handlers/MessageConverter.java
@@ -1,0 +1,19 @@
+package com.oisp.databackend.handlers;
+
+import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.converter.cbor.MappingJackson2CborHttpMessageConverter;
+
+@Configuration
+public class MessageConverter {
+    @Bean
+    public HttpMessageConverters customConverters() {
+        HttpMessageConverter<?> additional = new MappingJackson2HttpMessageConverter();
+        HttpMessageConverter<?> another = new MappingJackson2CborHttpMessageConverter();
+        return new HttpMessageConverters(additional, another);
+    }
+
+}

--- a/src/test/java/com/oisp/databackend/api/FirstLastTimestampTest.java
+++ b/src/test/java/com/oisp/databackend/api/FirstLastTimestampTest.java
@@ -90,7 +90,7 @@ public class FirstLastTimestampTest {
         List<String> componentsList = new ArrayList<>();
         componentsList.add("test");
 
-        Mockito.when(dataDaoMock.scan(accountId, "test", 0L, Long.MAX_VALUE, false, null, true, 1)).thenReturn(new Observation[0]);
+        Mockito.when(dataDaoMock.scan(accountId, "test", "Number", 0L, Long.MAX_VALUE, false, null, true, 1)).thenReturn(new Observation[0]);
 
         FirstLastTimestampRequest request = new FirstLastTimestampRequest();
         request.setComponents(new ArrayList<String>());
@@ -114,8 +114,8 @@ public class FirstLastTimestampTest {
 
         Observation[] observations = new Observation[]{new Observation("aid", "cid", 1, "val")};
 
-        Mockito.when(dataDaoMock.scan(accountId, "test", 0L, Long.MAX_VALUE, false, null, true, 1)).thenReturn(observations);
-        Mockito.when(dataDaoMock.scan(accountId, "test", 0L, Long.MAX_VALUE, false, null, false, 1)).thenReturn(observations);
+        Mockito.when(dataDaoMock.scan(accountId, "test", "ByteArray", 0L, Long.MAX_VALUE, false, null, true, 1)).thenReturn(observations);
+        Mockito.when(dataDaoMock.scan(accountId, "test", "ByteArray",0L, Long.MAX_VALUE, false, null, false, 1)).thenReturn(observations);
 
         FirstLastTimestampRequest request = new FirstLastTimestampRequest();
         request.setComponents(new ArrayList<String>());

--- a/src/test/java/com/oisp/databackend/api/inquiry/advanced/AdvancedDataInquiryServiceTest.java
+++ b/src/test/java/com/oisp/databackend/api/inquiry/advanced/AdvancedDataInquiryServiceTest.java
@@ -67,7 +67,7 @@ public class AdvancedDataInquiryServiceTest {
         assertEquals(accountId, response.getAccountId());
         assertEquals(0, response.getData().size());
         assertEquals(null, response.getRowCount());
-        Mockito.verify(dataDaoMock, Mockito.times(0)).scan(any(String.class), any(String.class), any(Long.class), any(Long.class), any(Boolean.class), any(String[].class));
+        Mockito.verify(dataDaoMock, Mockito.times(0)).scan(any(String.class), any(String.class), any(String.class), any(Long.class), any(Long.class), any(Boolean.class), any(String[].class));
     }
 
     @Test
@@ -81,11 +81,13 @@ public class AdvancedDataInquiryServiceTest {
         DeviceData deviceData = new DeviceData();
         AdvancedComponent advancedComponent = new AdvancedComponent();
         advancedComponent.setComponentId(observation.getCid());
+        advancedComponent.setDataType("Number");
         deviceData.setComponents(Arrays.asList(advancedComponent));
         request.setDeviceDataList(Arrays.asList(deviceData));
 
         Mockito.when(dataDaoMock.put(any(Observation[].class))).thenReturn(true);
         Mockito.when(dataDaoMock.scan(any(String.class),
+                any(String.class),
                 any(String.class),
                 any(Long.class),
                 any(Long.class),
@@ -131,12 +133,14 @@ public class AdvancedDataInquiryServiceTest {
         DeviceData deviceData = new DeviceData();
         AdvancedComponent advancedComponent = new AdvancedComponent();
         advancedComponent.setComponentId(observation.getCid());
+        advancedComponent.setDataType("Number");
         deviceData.setComponents(Arrays.asList(advancedComponent));
         request.setDeviceDataList(Arrays.asList(deviceData));
         request.setCountOnly(true);
 
         Mockito.when(dataDaoMock.put(any(Observation[].class))).thenReturn(true);
         Mockito.when(dataDaoMock.scan(any(String.class),
+                any(String.class),
                 any(String.class),
                 any(Long.class),
                 any(Long.class),

--- a/src/test/java/com/oisp/databackend/api/inquiry/basic/BasicDataInquiryServiceTest.java
+++ b/src/test/java/com/oisp/databackend/api/inquiry/basic/BasicDataInquiryServiceTest.java
@@ -55,14 +55,14 @@ public class BasicDataInquiryServiceTest {
         observations[1] = new Observation("2", componentId, 4L, "6");
         firstObservation = observations[0];
         secondObservation = observations[1];
-        Mockito.when(dataDaoMock.scan(accountId, componentId, request.getStartDate(), request.getEndDate(), false, null)).thenReturn(observations);
+        Mockito.when(dataDaoMock.scan(accountId, componentId, "Number", request.getStartDate(), request.getEndDate(), false, null)).thenReturn(observations);
     }
 
-    private String getFirstObservationValue(DataInquiryResponse response) {
+    private Object getFirstObservationValue(DataInquiryResponse response) {
         return response.getComponents().get(0).getSamples().get(0).get(1);
     }
 
-    private String getFirstObservationOn(DataInquiryResponse response) {
+    private Object getFirstObservationOn(DataInquiryResponse response) {
         return response.getComponents().get(0).getSamples().get(0).get(0);
     }
 
@@ -91,11 +91,13 @@ public class BasicDataInquiryServiceTest {
         request.setEndDate(1L);
         request.setCountOnly(true);
         Map<String, ComponentDataType> components = new HashMap<>();
-        components.put(componentId, new ComponentDataType());
+        ComponentDataType type = new ComponentDataType();
+        type.setDataType(ComponentDataType.NUMBER);
+        components.put(componentId, type);
         request.setComponentsWithDataType(components);
 
         Observation[] observations = new Observation[2];
-        Mockito.when(dataDaoMock.scan(accountId, componentId, request.getStartDate(), request.getEndDate(), false, null)).thenReturn(observations);
+        Mockito.when(dataDaoMock.scan(accountId, componentId, "Number", request.getStartDate(), request.getEndDate(), false, null)).thenReturn(observations);
 
         basicDataInquiryService = basicDataInquiryService.withParams(accountId, request);
         //ACT
@@ -112,7 +114,9 @@ public class BasicDataInquiryServiceTest {
         request.setEndDate(1L);
         request.setCountOnly(false);
         Map<String, ComponentDataType> components = new HashMap<>();
-        components.put(componentId, new ComponentDataType());
+        ComponentDataType type = new ComponentDataType();
+        type.setDataType(ComponentDataType.NUMBER);
+        components.put(componentId, type);
         request.setComponentsWithDataType(components);
         basicDataInquiryService = basicDataInquiryService.withParams(accountId, request);
 
@@ -124,7 +128,7 @@ public class BasicDataInquiryServiceTest {
         assertEquals((Long) 2L, response.getRowCount());
         assertEquals(accountId, response.getAccountId());
         assertEquals(componentId, response.getComponents().get(0).getComponentId());
-        assertEquals(firstObservation.getOn().toString(), getFirstObservationOn(response));
+        assertEquals(firstObservation.getOn(), getFirstObservationOn(response));
         assertEquals(firstObservation.getValue(), getFirstObservationValue(response));
         assertEquals(null, response.getMaxPoints());
     }

--- a/src/test/java/com/oisp/databackend/api/inquiry/samples/SampleAggregationDataRetrieverTest.java
+++ b/src/test/java/com/oisp/databackend/api/inquiry/samples/SampleAggregationDataRetrieverTest.java
@@ -42,7 +42,7 @@ public class SampleAggregationDataRetrieverTest {
         SampleAggregationDataRetriever instance = new SampleAggregationDataRetriever(params);
 
         //ACT
-        List<List<String>> result = instance.get(observations, null, null);
+        List<List<Object>> result = instance.get(observations, null, null);
 
         //ASSERT
         //values are averaged in each bucket
@@ -61,7 +61,7 @@ public class SampleAggregationDataRetrieverTest {
         SampleAggregationDataRetriever instance = new SampleAggregationDataRetriever(params);
 
         //ACT
-        List<List<String>> result = instance.get(observations, null, null);
+        List<List<Object>> result = instance.get(observations, null, null);
 
         //ASSERT
         assertEquals(result, Arrays.asList(Arrays.asList("10", "200.0"), Arrays.asList("11", "201.0")));
@@ -82,7 +82,7 @@ public class SampleAggregationDataRetrieverTest {
         SampleAggregationDataRetriever instance = new SampleAggregationDataRetriever(params);
 
         //ACT
-        List<List<String>> result = instance.get(observations, null, null);
+        List<List<Object>> result = instance.get(observations, null, null);
 
         //ASSERT
         //bucket size is floor(999ms/300) = 3ms


### PR DESCRIPTION
*Updated springframework and dependencies to v2.1.2. Needed for adding default cbor http body decoder
*Added new gradle version to Dockerfile to work with most recent springframework
*Pass in dataType to differentiate between binary and non binary data
*Search request: Added cbor as return value options. Moved return data type from String to generic Objcet to allow Buffers
*Added IllegalDataInquiryArgumentException to DataRetriever
*Added basic data types and validity checks to ComponentDataType class
*Fixed Unit tests to handle DtaTypes
*Cleanup and raising the bar for pmdmain's paremeter number checks to 9

Signed-off-by: Marcel Wagner <wagmarcel@web.de>