### PR TITLE
Added KairosDB as TSDB backend

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -37,15 +37,15 @@
         <module name="CovariantEquals"/>
 
         <module name="NestedIfDepth">
-            <property name="max" value="2"/>
+            <property name="max" value="4"/>
         </module>
 
         <module name="NestedTryDepth">
-            <property name="max" value="2"/>
+            <property name="max" value="4"/>
         </module>
 
         <module name="NestedForDepth">
-            <property name="max" value="2"/>
+            <property name="max" value="4"/>
         </module>
 
         <module name="LocalFinalVariableName"/>

--- a/src/main/java/com/oisp/databackend/config/oisp/OispConfig.java
+++ b/src/main/java/com/oisp/databackend/config/oisp/OispConfig.java
@@ -20,6 +20,7 @@ public class OispConfig {
     public static final String OISP_BACKEND_TSDB_NAME_DUMMY = "dummy";
     public static final String OISP_BACKEND_TSDB_NAME_HBASE = "hbase";
     public static final String OISP_BACKEND_TSDB_NAME_OPENTSDB = "openTSDB";
+    public static final String OISP_BACKEND_TSDB_NAME_KAIROSDB = "kairosDB";
 
     //Object Store types
     public static final String OISP_BACKEND_OBJECT_STORE_MINIO = "minio";

--- a/src/main/java/com/oisp/databackend/datasources/DataDaoImpl.java
+++ b/src/main/java/com/oisp/databackend/datasources/DataDaoImpl.java
@@ -55,7 +55,7 @@ public class DataDaoImpl implements DataDao {
 
     @Autowired
     DataDaoImpl() {
-        logger.info("Marcel: created!");
+        logger.info("Dao created!");
     }
 
     @Autowired
@@ -70,6 +70,9 @@ public class DataDaoImpl implements DataDao {
         } else if (oispConfig.OISP_BACKEND_TSDB_NAME_OPENTSDB.equals(tsdbName)) {
             logger.info("TSDB backend: openTSDB");
             this.tsdbAccess = (TsdbAccess) context.getBean("tsdbAccessOpenTsdb");
+        } else if (oispConfig.OISP_BACKEND_TSDB_NAME_KAIROSDB.equals(tsdbName)) {
+            logger.info("TSDB backend: kairosDB");
+            this.tsdbAccess = (TsdbAccess) context.getBean("tsdbAccessKairosDb");
         } else {
             throw new ConfigEnvironmentException("Could not find the tsdb backend with name " + tsdbName);
         }

--- a/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/ObservationBuilder.java
+++ b/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/ObservationBuilder.java
@@ -1,0 +1,152 @@
+package com.oisp.databackend.datasources.tsdb.kairosdb;
+
+import com.oisp.databackend.datasources.DataFormatter;
+import com.oisp.databackend.datasources.tsdb.TsdbQuery;
+import com.oisp.databackend.datasources.tsdb.kairosdb.kairosdbapi.Queries;
+import com.oisp.databackend.datasources.tsdb.kairosdb.kairosdbapi.QueryResponse;
+import com.oisp.databackend.datasources.tsdb.kairosdb.kairosdbapi.Result;
+import com.oisp.databackend.datastructures.Observation;
+
+import java.util.*;
+
+public final class ObservationBuilder {
+
+    private ObservationBuilder() {
+
+    }
+
+    private static void addTagsFromQuery(SortedMap<Long, Observation> observationsMap, QueryResponse queryResponse) {
+        for (Queries queries : queryResponse.getQueries()) {
+            if (queries.getSampleSize() == 0) {
+                continue;
+            }
+            for (Result result: queries.getResults()) {
+                Map<String, List<String>> types = result.getTags();
+                List<Object[]> dps = result.getValues();
+                for (Map.Entry<String, List<String>> type : types.entrySet()) {
+                    String tagK = type.getKey();
+                    if (tagK.equals(TsdbObjectBuilder.TYPE)) {
+                        continue;
+                    }
+                    for (String tagV : type.getValue()) {
+                        for (Object[] entry : dps) {
+                            Long timestamp = (Long) entry[0];
+                            if (observationsMap.get(timestamp) != null) {
+                                observationsMap.get(timestamp).getAttributes().put(tagK, tagV);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static void addGpsFromQuery(SortedMap<Long, Observation> observationsMap, QueryResponse queryResponse) {
+        for (Queries queries : queryResponse.getQueries()) {
+
+            for (Result result: queries.getResults()) {
+                if (queries.getSampleSize() == 0) {
+                    continue;
+                }
+                String type = result.getTags().get(TsdbObjectBuilder.TYPE).get(0); // type is unique there cannot be different types
+                if (!type.equals(DataFormatter.gpsValueToString(0))
+                        && !type.equals(DataFormatter.gpsValueToString(1))
+                        && !type.equals(DataFormatter.gpsValueToString(2))) {
+                    continue;
+                }
+                List<Object[]> dps = result.getValues();
+                for (Object[] value: dps) {
+                    Long timestamp = (Long) value[0];
+                    String finalValue = value[1].toString();
+                    if (observationsMap.get(timestamp) != null) {
+                        observationsMap.get(timestamp).getAttributes().put(type, finalValue);
+                    }
+                }
+            }
+        }
+    }
+
+    private static SortedMap<Long, Observation> createBaseObservations(QueryResponse queryResponse, TsdbQuery tsdbQuery) {
+
+        SortedMap<Long, Observation> observationMap = new TreeMap<>();
+
+        for (Queries queries: queryResponse.getQueries()) {
+            if (queries.getSampleSize() == 0) {
+                continue;
+            }
+            for (Result result: queries.getResults()) {
+                if (result.getTags().get(TsdbObjectBuilder.TYPE).stream().filter(f -> f.equals(TsdbObjectBuilder.VALUE)).findAny().orElse(null) == null) {
+                    continue;
+                }
+                String metric = result.getName();
+                List<Object[]> dps = result.getValues();
+                for (Object[] value: dps) {
+                    Long timestamp = (Long) value[0];
+                    String finalValue = value[1].toString();
+                    Observation observation = new Observation(DataFormatter.getAccountFromMetric(metric),
+                            DataFormatter.getCidFromMetric(metric),
+                            timestamp, finalValue, new ArrayList<Double>(), new HashMap<String, String>());
+                    observation.setDataType(tsdbQuery.getComponentType());
+                    observationMap.put(timestamp, observation);
+                }
+            }
+        }
+        return observationMap;
+    }
+
+    public static Observation[] createObservationFromQueryResponses(QueryResponse queryResponse, TsdbQuery tsdbQuery) {
+
+        //first create the base objets with the value types
+        SortedMap<Long, Observation> observationMap
+                = createBaseObservations(queryResponse, tsdbQuery);
+
+        //Now add the gps tags if any
+        addGpsFromQuery(observationMap, queryResponse);
+        convertGpsAttributesToLoc(observationMap);
+
+        //Now add the other tags
+        addTagsFromQuery(observationMap, queryResponse);
+
+        // collect finally objects in an array
+        return observationMap.values().toArray(new Observation[0]);
+    }
+
+
+    private static void convertGpsAttributesToLoc(SortedMap<Long, Observation> observationMap) {
+        for (Observation observation: observationMap.values()) {
+            Map<String, String> attributes = observation.getAttributes();
+            if (attributes.isEmpty()) {
+                continue;
+            }
+            String[] coord = {
+                    attributes.get(DataFormatter.gpsValueToString(0)),
+                    attributes.get(DataFormatter.gpsValueToString(1)),
+                    attributes.get(DataFormatter.gpsValueToString(2))
+            };
+            List<Double> loc = new ArrayList<>();
+            for (int i = 0; i < DataFormatter.GPS_COLUMN_SIZE;  i++) {
+                if (coord[i] != null) {
+                    loc.add(Double.parseDouble(coord[i]));
+                }
+            }
+            observation.setLoc(loc);
+        }
+    }
+
+    public static boolean checkforTagMap(Map<String, String> attributes) {
+        boolean keepTagMapEmpty = false;
+
+        if (!attributes.isEmpty()) {
+            for (String attribute : attributes.keySet()) {
+                if (attribute != DataFormatter.gpsValueToString(0)
+                        && attribute != DataFormatter.gpsValueToString(1)
+                        && attribute != DataFormatter.gpsValueToString(2)) {
+                    keepTagMapEmpty = true;
+                    break;
+                }
+            }
+        }
+
+        return keepTagMapEmpty;
+    }
+}

--- a/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/TsdbAccessKairosDb.java
+++ b/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/TsdbAccessKairosDb.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) 2015 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oisp.databackend.datasources.tsdb.kairosdb;
+
+import com.oisp.databackend.config.oisp.OispConfig;
+import com.oisp.databackend.datasources.DataFormatter;
+import com.oisp.databackend.datasources.DataType;
+import com.oisp.databackend.datasources.tsdb.TsdbAccess;
+import com.oisp.databackend.datasources.tsdb.TsdbQuery;
+import com.oisp.databackend.datasources.tsdb.kairosdb.kairosdbapi.Aggregator;
+import com.oisp.databackend.datasources.tsdb.kairosdb.kairosdbapi.Query;
+import com.oisp.databackend.datasources.tsdb.kairosdb.kairosdbapi.QueryResponse;
+import com.oisp.databackend.datasources.tsdb.kairosdb.kairosdbapi.RestApi;
+import com.oisp.databackend.datasources.tsdb.kairosdb.kairosdbapi.Sampling;
+import com.oisp.databackend.datasources.tsdb.kairosdb.kairosdbapi.SubQuery;
+
+import com.oisp.databackend.datastructures.Observation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+@Repository
+public class TsdbAccessKairosDb implements TsdbAccess {
+
+    private static final String STAR = "*";
+    private static final Long MAX_YEARS_COUNT_AGGREGATION = 10L; //max count over 10 years
+    private RestApi api;
+    @Autowired
+    private OispConfig oispConfig;
+
+
+    @PostConstruct
+    public void init() throws URISyntaxException {
+        //Make sure that this bean is only initiated when needed
+        if (!oispConfig.getBackendConfig()
+                .getTsdbName()
+                .equals(oispConfig.OISP_BACKEND_TSDB_NAME_KAIROSDB)) {
+            return;
+        }
+        api = new RestApi(oispConfig);
+    }
+
+    @Override
+    public boolean put(List<Observation> observations, boolean onlyMetadata) {
+        List<TsdbObject> tsdbObjects = TsdbObjectBuilder.createTsdbObjectsFromObservations(observations, onlyMetadata);
+
+        return api.put(tsdbObjects, true);
+    }
+
+    @Override
+    public boolean put(Observation observation, boolean onlyMetadata) {
+
+        List<Observation> list = new ArrayList<Observation>();
+        list.add(observation);
+
+        return put(list, onlyMetadata);
+    }
+
+    @Override
+    public Observation[] scan(TsdbQuery tsdbQuery) {
+        SubQuery subQuery = new SubQuery()
+                //.withAggregator(SubQuery.AGGREGATOR_NONE)
+                .withMetric(DataFormatter.createMetric(tsdbQuery.getAid(),
+                        tsdbQuery.getCid()));
+        List<String> types = new ArrayList<String>();
+        List<String> tagNames = new ArrayList<String>();
+        tagNames.add(TsdbObjectBuilder.TYPE);
+        types.add(TsdbObjectBuilder.VALUE);
+        if (tsdbQuery.isLocationInfo()) {
+            types.add(DataFormatter.gpsValueToString(0));
+            types.add(DataFormatter.gpsValueToString(1));
+            types.add(DataFormatter.gpsValueToString(2));
+        }
+        if (!tsdbQuery.getAttributes().isEmpty()) {
+            List<String> requestedTags = new ArrayList<String>();
+            if (tsdbQuery.getAttributes().get(0).equals(STAR)) {
+                // tags are not known yet, but all tags are requested
+                // Therefore we need to query all relevant tags from Kairosdb
+                Query query = new Query().withStart(tsdbQuery.getStart()).withEnd(tsdbQuery.getStop());
+                query.addQuery(subQuery);
+                QueryResponse queryResponses = api.queryTags(query);
+                if (queryResponses != null) {
+                    requestedTags = new ArrayList<String>(queryResponses.getQueries().get(0).getResults().get(0).getTags().keySet());
+                }
+            } else {
+                // tags are given explicitly. No additional tag query needed
+                requestedTags = tsdbQuery.getAttributes();
+            }
+            List<String> mergedNames = Stream.of(tagNames, requestedTags).flatMap(x -> x.stream()).collect(Collectors.toList());
+            tagNames = mergedNames;
+        }
+        subQuery.withTag(TsdbObjectBuilder.TYPE, types);
+        subQuery.withGroupByTags(tagNames);
+
+        Query query = new Query().withStart(tsdbQuery.getStart()).withEnd(tsdbQuery.getStop());
+        query.addQuery(subQuery);
+
+        QueryResponse queryResponses = api.query(query);
+        if (queryResponses == null) {
+            return null;
+        }
+        return ObservationBuilder.createObservationFromQueryResponses(queryResponses, tsdbQuery);
+    }
+
+    @Override
+    public Observation[] scan(TsdbQuery tsdbQuery, boolean forward, int limit) {
+        return new Observation[0];
+    }
+
+    @Override
+    public Long count(TsdbQuery tsdbQuery) {
+        SubQuery subQuery = new SubQuery()
+                .withAggregator(new Aggregator(Aggregator.AGGREGATOR_COUNT)
+                        .withSampling(new Sampling(MAX_YEARS_COUNT_AGGREGATION, "years")))
+                .withMetric(DataFormatter.createMetric(tsdbQuery.getAid(),
+                        tsdbQuery.getCid()));
+
+
+        // Tag list contains at least "type = value" to count only "true" values (and e.g. not gps coordinates)
+        // When more attributes are given, only the samples additionally containing the attribute are count.
+        // e.g. when sample1 has attribute(key1=value1) and sample2 (key2=value2) and sample3 (key2=value3) then if key2
+        // is given only sample2 and sample3 are considered
+        List<String> tags = new ArrayList<String>();
+        tags.add(TsdbObjectBuilder.VALUE);
+
+        if (!tsdbQuery.getAttributes().isEmpty() && tsdbQuery.getAttributes().get(0).equals(STAR)) {
+            tags = Stream.of(tags, tsdbQuery.getAttributes()).flatMap(x -> x.stream()).collect(Collectors.toList());
+        }
+
+        subQuery.withTag(TsdbObjectBuilder.TYPE, tags);
+        Query query = new Query()
+                .withStart(tsdbQuery.getStart())
+                .withEnd(tsdbQuery.getStop());
+        query.addQuery(subQuery);
+
+        QueryResponse queryResponses = api.query(query);
+        if (queryResponses == null) {
+            return 0L;
+        }
+        Long count = queryResponses.getQueries().stream()
+                .flatMap(x -> x.getResults().stream())
+                .flatMap(qr -> qr.getValues().stream())
+                .map(obj -> new Long((Integer) obj[1]))
+                .reduce(0L, (e1, e2) -> e1 + e2);
+        return count;
+        //return 0L;
+    }
+    
+    public String[] scanForAttributeNames(TsdbQuery tsdbQuery) throws IOException {
+        return new String[]{STAR};
+    }
+
+    @Override
+    public List<DataType.Types> getSupportedDataTypes() {
+        return Arrays.asList(DataType.Types.Boolean, DataType.Types.Number, DataType.Types.String);
+    }
+}

--- a/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/TsdbObject.java
+++ b/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/TsdbObject.java
@@ -1,0 +1,106 @@
+package com.oisp.databackend.datasources.tsdb.kairosdb;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Main abstraction for Kairos TSDB objects
+ *
+ */
+public class TsdbObject implements Serializable {
+    private String name;
+    private String value;
+    private String type;
+    private long timestamp;
+    private Map<String, String> attributes;
+
+    public TsdbObject(String metric, String value, long timestamp, Map<String, String> attributes) {
+        this.name = metric;
+        this.value  = value;
+        this.timestamp = timestamp;
+        this.attributes = attributes;
+    }
+
+    public TsdbObject(String metric, String value, long timestamp) {
+        this.name = metric;
+        this.value  = value;
+        this.timestamp = timestamp;
+        this.attributes = new HashMap<String, String>();
+    }
+
+    public TsdbObject() {
+        attributes = new HashMap<String, String>();
+    }
+
+    public TsdbObject(TsdbObject o) {
+        this.name = o.getName();
+        this.value = o.getValue();
+        this.timestamp = o.getTimestamp();
+        this.attributes = new HashMap<String, String>();
+    }
+
+    public TsdbObject withMetric(String metric) {
+        this.setName(metric);
+        return this;
+    }
+
+    public TsdbObject withValue(String value) {
+        this.value = value;
+        return this;
+    }
+
+    public TsdbObject withType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    public TsdbObject withTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+        return this;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public void setAttribute(String attributeK, String attributeV) {
+        attributes.put(attributeK, attributeV);
+    }
+
+    public void setAllAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/TsdbObjectBuilder.java
+++ b/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/TsdbObjectBuilder.java
@@ -1,0 +1,89 @@
+package com.oisp.databackend.datasources.tsdb.kairosdb;
+
+import com.oisp.databackend.datasources.DataFormatter;
+import com.oisp.databackend.datasources.DataType;
+import com.oisp.databackend.datastructures.Observation;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public final class TsdbObjectBuilder {
+    static final String VALUE = "value";
+    static final String TYPE = "type";
+
+    private TsdbObjectBuilder() {
+
+    }
+
+    private static void addTypeAttribute(TsdbObject tsdbObject, String attr) {
+        tsdbObject.setAttribute(TYPE, attr);
+    }
+
+    public static void addTypeAttributes(List<TsdbObject> tsdbObjects, String attr) {
+        for (TsdbObject tsdbObject: tsdbObjects) {
+            addTypeAttribute(tsdbObject, attr);
+        }
+    }
+
+    public static List<TsdbObject> extractLocationObjects(Observation observation) {
+        if (observation.getLoc() == null || observation.getLoc().isEmpty()) {
+            return new ArrayList<TsdbObject>();
+        }
+        String metric = DataFormatter.createMetric(observation.getAid(), observation.getCid());
+        List<TsdbObject> tsdbObjects = new ArrayList<TsdbObject>();
+        for (int i = 0; i < observation.getLoc().size(); i++) {
+            TsdbObject tsdbObject = new TsdbObject(metric, observation.getLoc().get(i).toString(), observation.getOn());
+            addTypeAttribute(tsdbObject, DataFormatter.gpsValueToString(i));
+            tsdbObjects.add(tsdbObject);
+        }
+        return tsdbObjects;
+    }
+
+    public static List<TsdbObject> createTsdbObjectsFromObservations(List<Observation> observations, boolean onlyMetadata) {
+        return observations.stream()
+                .flatMap(element
+                        -> getTsdbObjectsfromObservation(element, onlyMetadata).stream())
+                .collect(Collectors.toList());
+    }
+
+    public static List<TsdbObject> getTsdbObjectsfromObservation(Observation o, boolean onlyMetadata) {
+
+        List<TsdbObject> tsdbObjects = new ArrayList<TsdbObject>();
+        String metric = DataFormatter.createMetric(o.getAid(), o.getCid());
+        long timestamp = o.getOn();
+        String value;
+        if (onlyMetadata) {
+            value = "1";
+        } else {
+            value = o.getValue();
+        }
+        String type;
+        DataType.Types otype = DataType.getType(o.getDataType());
+        if (otype == DataType.Types.Boolean) {
+            type = "long";
+        } else if (otype == DataType.Types.String) {
+            type = "string";
+        } else {
+            type = "double";
+        }
+
+        TsdbObject put = new TsdbObject()
+                .withMetric(metric)
+                .withTimestamp(timestamp)
+                .withType(type)
+                .withValue(value);
+        Map<String, String> attributes = o.getAttributes();
+        if (attributes == null) {
+            attributes = new HashMap<>();
+        }
+        List<TsdbObject> tsdbObjectsWithLoc = extractLocationObjects(o);
+        put.setAllAttributes(attributes);
+        addTypeAttribute(put, VALUE);
+        tsdbObjects.add(put);
+        tsdbObjects.addAll(tsdbObjectsWithLoc);
+        return tsdbObjects;
+    }
+}

--- a/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/kairosdbapi/Aggregator.java
+++ b/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/kairosdbapi/Aggregator.java
@@ -1,0 +1,72 @@
+package com.oisp.databackend.datasources.tsdb.kairosdb.kairosdbapi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Aggregator {
+    public static final String AGGREGATOR_COUNT = "count";
+    public static final String AGGREGATOR_SUM = "sum";
+    //public static final String AGGREGATOR_MIN = "min";
+    //public static final String AGGREGATOR_NONE = "none";
+
+    private String name;
+    private Sampling sampling;
+    private Boolean alignSampling;
+    private Boolean alignStartTime;
+    private Boolean alignEndTime;
+
+    public Aggregator(String name) {
+        this.name = name;
+        sampling = null;
+        alignEndTime = false;
+        alignSampling = false;
+        alignStartTime = false;
+    }
+
+    public Aggregator withSampling(Sampling sampling) {
+        this.sampling = sampling;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Sampling getSampling() {
+        return sampling;
+    }
+
+    public void setSampling(Sampling sampling) {
+        this.sampling = sampling;
+    }
+
+    @JsonProperty("align_sampling")
+    public Boolean getAlignSampling() {
+        return alignSampling;
+    }
+
+    public void setAlignSampling(Boolean alignSampling) {
+        this.alignSampling = alignSampling;
+    }
+
+    @JsonProperty("align_start_time")
+    public Boolean getAlignStartTime() {
+        return alignStartTime;
+    }
+
+    public void setAlignStartTime(Boolean alignStartTime) {
+        this.alignStartTime = alignStartTime;
+    }
+
+    @JsonProperty("align_end_time")
+    public Boolean getAlignEndTime() {
+        return alignEndTime;
+    }
+
+    public void setAlignEndTime(Boolean alignEndTime) {
+        this.alignEndTime = alignEndTime;
+    }
+}

--- a/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/kairosdbapi/GroupBy.java
+++ b/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/kairosdbapi/GroupBy.java
@@ -1,0 +1,46 @@
+package com.oisp.databackend.datasources.tsdb.kairosdb.kairosdbapi;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GroupBy {
+    private String name;
+    private String type;
+    private List<String> tags;
+    private Map<String, String> group;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public Map<String, String> getGroup() {
+        return group;
+    }
+
+    public void setGroup(Map<String, String> group) {
+        this.group = group;
+    }
+}

--- a/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/kairosdbapi/Queries.java
+++ b/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/kairosdbapi/Queries.java
@@ -1,0 +1,31 @@
+package com.oisp.databackend.datasources.tsdb.kairosdb.kairosdbapi;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Queries {
+
+    private Integer sampleSize;
+    private List<Result> results;
+
+    @JsonProperty("sample_size")
+    public Integer getSampleSize() {
+        return sampleSize;
+    }
+
+    public void setSampleSize(Integer sampleSize) {
+        this.sampleSize = sampleSize;
+    }
+
+    public List<Result> getResults() {
+        return results;
+    }
+
+    public void setResults(List<Result> results) {
+        this.results = results;
+    }
+
+}

--- a/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/kairosdbapi/Query.java
+++ b/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/kairosdbapi/Query.java
@@ -1,0 +1,74 @@
+package com.oisp.databackend.datasources.tsdb.kairosdb.kairosdbapi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Query {
+    private long startAbsolute;
+    private long endAbsolute;
+    private List<SubQuery> metrics;
+    //private boolean msResolution;
+
+    public Query() {
+        this.metrics = new ArrayList<SubQuery>();
+      //  this.msResolution = true;
+    }
+    public Query withStart(long start) {
+        this.startAbsolute = start;
+        return this;
+    }
+
+    public Query withEnd(long end) {
+        this.endAbsolute = end;
+        return this;
+    }
+    public void setEndAbsolute(long endAbsolute) {
+        this.endAbsolute = endAbsolute;
+    }
+
+    public void setMetrics(List<SubQuery> metrics) {
+        this.metrics = metrics;
+    }
+
+    public void setStartAbsolute(long startAbsolute) {
+        this.startAbsolute = startAbsolute;
+    }
+
+    @JsonProperty("end_absolute")
+    public long getEndAbsolute() {
+        return endAbsolute;
+    }
+
+    @JsonProperty("start_absolute")
+    public long getStartAbsolute() {
+        return startAbsolute;
+    }
+
+    public List<SubQuery> getMetrics() {
+        return metrics;
+    }
+
+    public void addQuery(SubQuery subQuery) {
+        this.metrics.add(subQuery);
+    }
+
+    /*public boolean isMsResolution() {
+        return msResolution;
+    }*/
+
+    @Override
+    public String toString() {
+        ObjectMapper mapper = new ObjectMapper();
+        String jsonObject = null;
+        try {
+            jsonObject = mapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+        return jsonObject;
+    }
+}

--- a/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/kairosdbapi/QueryResponse.java
+++ b/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/kairosdbapi/QueryResponse.java
@@ -1,0 +1,15 @@
+package com.oisp.databackend.datasources.tsdb.kairosdb.kairosdbapi;
+
+import java.util.List;
+
+public class QueryResponse {
+    private List<Queries> queries;
+
+    public List<Queries> getQueries() {
+        return queries;
+    }
+
+    public void setQueries(List<Queries> queries) {
+        this.queries = queries;
+    }
+}

--- a/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/kairosdbapi/RestApi.java
+++ b/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/kairosdbapi/RestApi.java
@@ -1,0 +1,210 @@
+package com.oisp.databackend.datasources.tsdb.kairosdb.kairosdbapi;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oisp.databackend.config.oisp.OispConfig;
+import com.oisp.databackend.datasources.tsdb.kairosdb.TsdbObject;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class RestApi {
+    private static final Logger logger = LoggerFactory.getLogger(RestApi.class);
+    public static final String CONTENT_TYPE_JSON = "application/json";
+    private static final String ATTRIBUTES = "\"attributes\":";
+    private static final String TAGS = "\"tags\":";
+    private static final String ACCEPT = "Accept";
+    private static final String CONTENTTYPE = "Content-type";
+    private static final int PUTOK = 204;
+    private static final int QUERYOK = 200;
+    private static final String CLOSING_BRACKET = "]";
+    private static final String OPENING_BRACKET = "[";
+
+    private URI putUri;
+    private URI queryUri;
+    private URI queryTagsUri;
+
+    public static final int MAXCHUNKSIZE = 4000;
+
+    public RestApi(OispConfig oispConfig) throws URISyntaxException {
+        String host;
+        int port;
+        String scheme;
+        scheme = "http";
+        host = oispConfig.getBackendConfig().getTsdbProperties().getProperty(OispConfig.OISP_BACKEND_TSDB_URI);
+        port = Integer.parseInt(oispConfig.getBackendConfig().getTsdbProperties().getProperty(OispConfig.OISP_BACKEND_TSDB_PORT));
+
+        putUri = new URIBuilder()
+                .setScheme(scheme)
+                .setPath("/api/v1/datapoints")
+                .setHost(host)
+                .setPort(port)
+                .build();
+        queryUri = new URIBuilder()
+                .setScheme(scheme)
+                .setPath("/api/v1/datapoints/query")
+                .setHost(host)
+                .setPort(port)
+                .setParameter("ms", null)
+                .build();
+        queryTagsUri = new URIBuilder()
+                .setScheme(scheme)
+                .setPath("/api/v1/datapoints/query/tags")
+                .setHost(host)
+                .setPort(port)
+                //.setParameter("ms", null)
+                .build();
+    }
+
+
+
+    public boolean put(List<TsdbObject> tsdbObjects, boolean sync) {
+
+        List<String> jsonObjects = tsdbObjectsToJSON(tsdbObjects);
+
+        CloseableHttpClient client = HttpClients.createDefault();
+
+        StringEntity entity = null;
+        for (String jsonObject: jsonObjects) {
+            String jsonObjectWithTags = jsonObject.replaceAll(Pattern.quote(ATTRIBUTES), TAGS);
+            HttpPost httpPost = new HttpPost(putUri);
+
+            try {
+                entity = new StringEntity(jsonObjectWithTags);
+
+                httpPost.setEntity(entity);
+                httpPost.setHeader(ACCEPT, CONTENT_TYPE_JSON);
+                httpPost.setHeader(CONTENTTYPE, CONTENT_TYPE_JSON);
+
+                CloseableHttpResponse response = client.execute(httpPost);
+                int statusCode = response.getStatusLine().getStatusCode();
+                logger.debug("StatusCode of put response: " + statusCode);
+                if (statusCode != PUTOK) {
+                    logger.error("Status code: {}, Error reason {}", statusCode, EntityUtils.toString(
+                            response.getEntity(), "UTF-8"));
+                    return false;
+                }
+            } catch (IOException e) {
+                logger.error("Could not create JSON payload for put POST request: " + e);
+            }
+        }
+        return true;
+    }
+
+    List<String> tsdbObjectsToJSON(List<TsdbObject> tsdbObjects) {
+        ObjectMapper mapper = new ObjectMapper();
+        List<String> resultObjects = new ArrayList<String>();
+        String remaining = tsdbObjects.stream()
+                .map((obj) -> {
+                        try {
+                            return mapper.writeValueAsString(obj);
+                        } catch (JsonProcessingException e) {
+                            logger.error("Could not convert object to JSON " + e);
+                            return "";
+                        }
+                    })
+                .reduce("", (collect, elem) -> {
+                        if (collect.isEmpty() || collect.length() + elem.length() > MAXCHUNKSIZE) {
+                            if (!collect.isEmpty()) {
+                                resultObjects.add(collect + CLOSING_BRACKET);
+                            }
+                            return OPENING_BRACKET + elem;
+                        } else {
+                            return collect + "," + elem;
+                        }
+                    });
+        resultObjects.add(remaining + CLOSING_BRACKET);
+        return resultObjects;
+    }
+
+    public QueryResponse query(Query query) {
+        String jsonObject = query.toString();
+        String jsonObjectWithTags = jsonObject.replaceAll(Pattern.quote(ATTRIBUTES), TAGS);
+        CloseableHttpClient client = HttpClients.createDefault();
+
+        HttpPost httpPost = new HttpPost(queryUri);
+        StringEntity entity = null;
+        String body = null;
+        try {
+            entity = new StringEntity(jsonObjectWithTags);
+
+            httpPost.setEntity(entity);
+            httpPost.setHeader(ACCEPT, CONTENT_TYPE_JSON);
+            httpPost.setHeader(CONTENTTYPE, CONTENT_TYPE_JSON);
+            CloseableHttpResponse response = client.execute(httpPost);
+            int statusCode = response.getStatusLine().getStatusCode();
+            logger.debug("StatusCode of query response: " + statusCode);
+            if (statusCode != QUERYOK) {
+                return null;
+            }
+            HttpEntity responseEntity = response.getEntity();
+
+            if (responseEntity != null) {
+                body = EntityUtils.toString(responseEntity);
+            }
+
+        } catch (IOException e) {
+            logger.error("Could not create JSON payload for query POST request: " + e);
+            return null;
+        }
+        return queryResponsefromString(body);
+    }
+
+    public QueryResponse queryTags(Query query) {
+        String jsonObject = query.toString();
+        String jsonObjectWithTags = jsonObject.replaceAll(Pattern.quote(ATTRIBUTES), TAGS);
+        CloseableHttpClient client = HttpClients.createDefault();
+
+        HttpPost httpPost = new HttpPost(queryTagsUri);
+        StringEntity entity = null;
+        String body = null;
+        try {
+            entity = new StringEntity(jsonObjectWithTags);
+
+            httpPost.setEntity(entity);
+            httpPost.setHeader(ACCEPT, CONTENT_TYPE_JSON);
+            httpPost.setHeader(CONTENTTYPE, CONTENT_TYPE_JSON);
+            CloseableHttpResponse response = client.execute(httpPost);
+            int statusCode = response.getStatusLine().getStatusCode();
+            logger.debug("StatusCode of queryTags response: " + statusCode);
+            if (statusCode != QUERYOK) {
+                return null;
+            }
+            HttpEntity responseEntity = response.getEntity();
+
+            if (responseEntity != null) {
+                body = EntityUtils.toString(responseEntity);
+            }
+
+        } catch (IOException e) {
+            logger.error("Could not create JSON payload for queryTags POST request: " + e);
+            return null;
+        }
+        return queryResponsefromString(body);
+    }
+
+    public QueryResponse queryResponsefromString(String jsonString) {
+        QueryResponse obj;
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            obj = mapper.readValue(jsonString, QueryResponse.class);
+        } catch (IOException e) {
+            return null;
+        }
+        return obj;
+    }
+}

--- a/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/kairosdbapi/Result.java
+++ b/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/kairosdbapi/Result.java
@@ -1,0 +1,46 @@
+package com.oisp.databackend.datasources.tsdb.kairosdb.kairosdbapi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+import java.util.List;
+
+public class Result {
+    private String name;
+    private List<GroupBy> groupBy;
+    private Map<String, List<String>> tags;
+    private List<Object[]> values;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonProperty("group_by")
+    public List<GroupBy> getGroupBy() {
+        return groupBy;
+    }
+
+    public void setGroupBy(List<GroupBy> groupBy) {
+        this.groupBy = groupBy;
+    }
+
+    public Map<String, List<String>> getTags() {
+        return tags;
+    }
+
+    public void setTags(Map<String, List<String>> tags) {
+        this.tags = tags;
+    }
+
+    public List<Object[]> getValues() {
+        return values;
+    }
+
+    public void setValues(List<Object[]> values) {
+        this.values = values;
+    }
+}

--- a/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/kairosdbapi/Sampling.java
+++ b/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/kairosdbapi/Sampling.java
@@ -1,0 +1,32 @@
+package com.oisp.databackend.datasources.tsdb.kairosdb.kairosdbapi;
+
+public class Sampling {
+    private Long value;
+    private String unit;
+
+    public Sampling() {
+        value = 1L;
+        unit = "milliseconds";
+    }
+
+    public Sampling(Long value, String unit) {
+        this.value = value;
+        this.unit = unit;
+    }
+
+    public Long getValue() {
+        return value;
+    }
+
+    public void setValue(Long value) {
+        this.value = value;
+    }
+
+    public String getUnit() {
+        return unit;
+    }
+
+    public void setUnit(String unit) {
+        this.unit = unit;
+    }
+}

--- a/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/kairosdbapi/SubQuery.java
+++ b/src/main/java/com/oisp/databackend/datasources/tsdb/kairosdb/kairosdbapi/SubQuery.java
@@ -1,0 +1,93 @@
+package com.oisp.databackend.datasources.tsdb.kairosdb.kairosdbapi;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SubQuery {
+
+    public static final Integer MAX_NUMBER_OF_SAMPLES = 1024 * 10;
+
+    private List<Aggregator> aggregators;
+    private String name;
+    private Integer limit;
+    private Map<String, List<String>> tags;
+    private List<GroupBy> groupBy;
+
+    @JsonProperty("group_by")
+    public List<GroupBy> getGroupBy() {
+        return groupBy;
+    }
+
+    public void setGroupBy(List<GroupBy> groupBy) {
+        this.groupBy = groupBy;
+    }
+
+    public SubQuery withGroupByTags(List<String> tags) {
+        GroupBy gb = new GroupBy();
+        gb.setName("tag");
+        gb.setTags(tags);
+        this.groupBy.add(gb);
+        return this;
+    }
+
+    public SubQuery() {
+        tags = new HashMap<String, List<String>>();
+        aggregators = new ArrayList<>();
+        limit = MAX_NUMBER_OF_SAMPLES;
+        groupBy = new ArrayList<GroupBy>();
+    }
+
+    public SubQuery withMetric(String metric) {
+        this.name = metric;
+        return this;
+    }
+
+    public SubQuery withAggregator(Aggregator aggregator) {
+        this.aggregators.add(aggregator);
+        return this;
+    }
+
+    public SubQuery withTag(String tagK, List<String> tagV) {
+        this.tags.put(tagK, tagV);
+        return this;
+    }
+
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public void setLimit(Integer limit) {
+        this.limit = limit;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setTags(Map<String, List<String>> tags) {
+        this.tags = tags;
+    }
+
+    public Map<String, List<String>> getTags() {
+        return tags;
+    }
+
+    public List<Aggregator> getAggregators() {
+        return aggregators;
+    }
+
+    public void setAggregators(List<Aggregator> aggregators) {
+        this.aggregators = aggregators;
+    }
+
+    public String getName() {
+        return name;
+    }
+}


### PR DESCRIPTION
* Allows to use Cassandra storage backend
* Can handle strings natively (in contrast to OpenTSDB)
* Is extensible to add more data-types, e.g. binary data (to get totally rid of Minio)
* Works with lightweight backend storage H2
* E2E tests working

Signed-off-by: Marcel Wagner <wagmarcel@web.de>